### PR TITLE
Remove check for 150 characters on alert to support new iOS alert pay…

### DIFF
--- a/lib/apn_on_rails/app/models/apn/notification.rb
+++ b/lib/apn_on_rails/app/models/apn/notification.rb
@@ -22,17 +22,6 @@ class APN::Notification < APN::Base
   belongs_to :device, :class_name => 'APN::Device'
   has_one    :app,    :class_name => 'APN::App', :through => :device
   
-  # Stores the text alert message you want to send to the device.
-  # 
-  # If the message is over 150 characters long it will get truncated
-  # to 150 characters with a <tt>...</tt>
-  def alert=(message)
-    if !message.blank? && message.size > 150
-      message = truncate(message, :length => 150)
-    end
-    write_attribute('alert', message)
-  end
-  
   # Creates a Hash that will be the payload of an APN.
   # 
   # Example:


### PR DESCRIPTION
…load specified in https://developer.apple.com/library/ios/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/Chapters/TheNotificationPayload.html
